### PR TITLE
CI: Parallel DEV/QA/PROD deploy to a single DB + README update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,33 @@
 pipeline {
   agent any
-  options { timestamps() }
+  options {
+    timestamps()
+    parallelsAlwaysFailFast()   // si una rama paralela falla, cancela las demás
+  }
 
   environment {
+    // Config común
     DB_HOST = 'localhost'
     DB_PORT = '3306'
-    DB_NAME = 'blog'      
-    DB_USER = 'root'      
-    DB_PASS = 'root'    
-    APP_PROFILE = ''
+    APP_PROFILE = ''      // 'prod' si manejas perfiles de Spring; vacío si no
+
+    // Puertos por ambiente (evitan choque local)
+    DEV_PORT  = '8081'
+    QA_PORT   = '8082'
+    PROD_PORT = '8083'
+
+    // DBs por ambiente (cámbialas si quieres)
+    DEV_DB  = 'blog_dev'
+    QA_DB   = 'blog_qa'
+    PROD_DB = 'blog_prod'
+
+    // Credenciales de ejemplo (cámbialas en tu entorno real)
+    DEV_USER  = 'root'
+    DEV_PASS  = 'root'
+    QA_USER   = 'root'
+    QA_PASS   = 'root'
+    PROD_USER = 'root'
+    PROD_PASS = 'root'
   }
 
   stages {
@@ -20,59 +39,112 @@ pipeline {
 
     stage('Build (sin tests)') {
       steps {
-        // Build “prod-like” sin compilar/ejecutar tests
         bat '.\\mvnw.cmd -B clean package -Dmaven.test.skip=true'
+      }
+    }
+
+    stage('Prepare (artefacto & git)') {
+      steps {
+        script {
+          // Detectar JAR construido
+          def listOut = bat(returnStdout: true, script: '@echo off\r\ndir /b target\\*.jar').trim()
+          def jarLines = listOut.readLines()
+          if (!jarLines || jarLines.isEmpty()) {
+            error 'No se encontró ningún JAR en target/*.jar'
+          }
+          env.JAR_PATH = ("target\\" + jarLines[0].trim())
+
+          // SHA corto para nombrar artefacto
+          def shaOut = bat(returnStdout: true, script: '@echo off\r\ngit rev-parse --short=12 HEAD').trim()
+          def lines = shaOut.readLines()
+          env.GIT_SHA = lines[lines.size() - 1].trim()
+
+          env.BUILD_NAME = "blog-back-${env.BUILD_NUMBER}-${env.GIT_SHA}.jar"
+        }
       }
     }
 
     stage('Stamp & Archive') {
       steps {
-        script {
-          // 1) Detectar el JAR generado (sin plugins extra)
-          def listOut = bat(returnStdout: true, script: '@echo off\r\ndir /b target\\*.jar').trim()
-          def jarLines = listOut.readLines()
-          if (jarLines == null || jarLines.isEmpty()) {
-            error 'No se encontró ningún JAR en target/*.jar'
-          }
-          env.JAR_PATH = ("target\\" + jarLines[0].trim())
-
-          // 2) Obtener GIT_SHA limpio (última línea)
-          def shaOut = bat(returnStdout: true, script: '@echo off\r\ngit rev-parse --short=12 HEAD').trim()
-          def lines = shaOut.readLines()
-          env.GIT_SHA = lines[lines.size() - 1].trim()
-
-          // 3) Nombre final del artefacto
-          env.BUILD_NAME = "blog-back-${env.BUILD_NUMBER}-${env.GIT_SHA}.jar"
-        }
-
-        // 4) Copiar y generar checksum con rutas entre comillas
         bat """
           copy /Y "${env.JAR_PATH}" "target\\${env.BUILD_NAME}"
           certutil -hashfile "target\\${env.BUILD_NAME}" SHA256 > "target\\${env.BUILD_NAME}.sha256.txt"
         """
-
-        // 5) Publicar artefactos
         archiveArtifacts artifacts: "target/${env.BUILD_NAME}, target/${env.BUILD_NAME}.sha256.txt", fingerprint: true
       }
     }
 
-    stage('Smoke run (MySQL local)') {
+    // --------- Despliegues no productivos en paralelo ---------
+    stage('Deploy non-prod (parallel)') {
+      parallel {
+        stage('Deploy DEV (smoke)') {
+          steps {
+            catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+              timeout(time: 40, unit: 'SECONDS') {
+                withEnv([
+                  "SPRING_PROFILES_ACTIVE=${APP_PROFILE}",
+                  "SPRING_DATASOURCE_URL=jdbc:mysql://${DB_HOST}:${DB_PORT}/${DEV_DB}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC",
+                  "SPRING_DATASOURCE_USERNAME=${DEV_USER}",
+                  "SPRING_DATASOURCE_PASSWORD=${DEV_PASS}",
+                  "SPRING_JPA_HIBERNATE_DDL_AUTO=update",
+                  "SERVER_PORT=${DEV_PORT}"
+                ]) {
+                  bat """
+                    echo [DEV] Ejecutando: ${env.JAR_PATH} en puerto %SERVER_PORT% con DB ${DEV_DB}
+                    java -jar "${env.JAR_PATH}"
+                  """
+                }
+              }
+            }
+          }
+        }
+
+        stage('Deploy QA (smoke)') {
+          steps {
+            catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+              timeout(time: 40, unit: 'SECONDS') {
+                withEnv([
+                  "SPRING_PROFILES_ACTIVE=${APP_PROFILE}",
+                  "SPRING_DATASOURCE_URL=jdbc:mysql://${DB_HOST}:${DB_PORT}/${QA_DB}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC",
+                  "SPRING_DATASOURCE_USERNAME=${QA_USER}",
+                  "SPRING_DATASOURCE_PASSWORD=${QA_PASS}",
+                  "SPRING_JPA_HIBERNATE_DDL_AUTO=update",
+                  "SERVER_PORT=${QA_PORT}"
+                ]) {
+                  bat """
+                    echo [QA] Ejecutando: ${env.JAR_PATH} en puerto %SERVER_PORT% con DB ${QA_DB}
+                    java -jar "${env.JAR_PATH}"
+                  """
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Gate manual antes de producción
+    stage('Aprobación para PRODUCCIÓN') {
       steps {
-        // Limitamos con timeout y no rompemos el build si expira (queda UNSTABLE).
+        input message: "¿Deploy a PRODUCCIÓN con artefacto ${env.BUILD_NAME}?", ok: "Continuar"
+      }
+    }
+
+    stage('Deploy PROD (smoke)') {
+      steps {
         catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
           timeout(time: 40, unit: 'SECONDS') {
             withEnv([
               "SPRING_PROFILES_ACTIVE=${APP_PROFILE}",
-              "SPRING_DATASOURCE_URL=jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC",
-              "SPRING_DATASOURCE_USERNAME=${DB_USER}",
-              "SPRING_DATASOURCE_PASSWORD=${DB_PASS}",
-              // Cambia a 'none' si NO quieres que toque el esquema en tu máquina
-              "SPRING_JPA_HIBERNATE_DDL_AUTO=update"
+              "SPRING_DATASOURCE_URL=jdbc:mysql://${DB_HOST}:${DB_PORT}/${PROD_DB}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC",
+              "SPRING_DATASOURCE_USERNAME=${PROD_USER}",
+              "SPRING_DATASOURCE_PASSWORD=${PROD_PASS}",
+              "SPRING_JPA_HIBERNATE_DDL_AUTO=update",
+              "SERVER_PORT=${PROD_PORT}"
             ]) {
               bat """
-                for %%f in (target\\*.jar) do ( set "APP_JAR=%%f" )
-                echo Ejecutando: %APP_JAR%
-                java -jar "%APP_JAR%"
+                echo [PROD] Ejecutando: ${env.JAR_PATH} en puerto %SERVER_PORT% con DB ${PROD_DB}
+                java -jar "${env.JAR_PATH}"
               """
             }
           }
@@ -83,7 +155,7 @@ pipeline {
 
   post {
     always {
-      echo "Listo. Artefactos en 'Artifacts'. Si el smoke marcó UNSTABLE es por timeout intencional."
+      echo "Artefactos publicados en 'Artifacts'. Los deploys son *smoke* con timeout (UNSTABLE esperado)."
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
     DB_HOST = 'localhost'
     DB_PORT = '3306'
     DB_NAME = 'blog'
-    DB_USER = 'root'
+    DB_USER = 'user'
     DB_PASS = 'root'
 
     // Puertos distintos por ambiente
@@ -111,3 +111,4 @@ pipeline {
     }
   }
 }
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,32 +2,24 @@ pipeline {
   agent any
   options {
     timestamps()
-    parallelsAlwaysFailFast()   // si una rama paralela falla, cancela las demás
+    // Si quieres que al fallar una rama se cancelen las demás, descomenta:
+    // parallelsAlwaysFailFast()
   }
 
   environment {
-    // Config común
-    DB_HOST = 'localhost'
+    // DB única para los 3 ambientes
+    DB_HOST = '127.0.0.1'
     DB_PORT = '3306'
-    APP_PROFILE = ''      // 'prod' si manejas perfiles de Spring; vacío si no
+    DB_NAME = 'blog'     // <<-- misma DB para DEV/QA/PROD
+    DB_USER = 'root'
+    DB_PASS = 'root'
 
-    // Puertos por ambiente (evitan choque local)
+    APP_PROFILE = ''     // usa 'prod' si manejas perfiles
+
+    // Puertos por ambiente (distintos, pero misma DB)
     DEV_PORT  = '8081'
     QA_PORT   = '8082'
     PROD_PORT = '8083'
-
-    // DBs por ambiente (cámbialas si quieres)
-    DEV_DB  = 'blog_dev'
-    QA_DB   = 'blog_qa'
-    PROD_DB = 'blog_prod'
-
-    // Credenciales de ejemplo (cámbialas en tu entorno real)
-    DEV_USER  = 'root'
-    DEV_PASS  = 'root'
-    QA_USER   = 'root'
-    QA_PASS   = 'root'
-    PROD_USER = 'root'
-    PROD_PASS = 'root'
   }
 
   stages {
@@ -54,12 +46,13 @@ pipeline {
           }
           env.JAR_PATH = ("target\\" + jarLines[0].trim())
 
-          // SHA corto para nombrar artefacto
+          // SHA corto para nombre
           def shaOut = bat(returnStdout: true, script: '@echo off\r\ngit rev-parse --short=12 HEAD').trim()
           def lines = shaOut.readLines()
           env.GIT_SHA = lines[lines.size() - 1].trim()
 
-          env.BUILD_NAME = "blog-back-${env.BUILD_NUMBER}-${env.GIT_SHA}.jar"
+          env.BUILD_NAME  = "blog-back-${env.BUILD_NUMBER}-${env.GIT_SHA}.jar"
+          env.RELEASE_JAR = "target\\${env.BUILD_NAME}"
         }
       }
     }
@@ -67,31 +60,29 @@ pipeline {
     stage('Stamp & Archive') {
       steps {
         bat """
-          copy /Y "${env.JAR_PATH}" "target\\${env.BUILD_NAME}"
-          certutil -hashfile "target\\${env.BUILD_NAME}" SHA256 > "target\\${env.BUILD_NAME}.sha256.txt"
+          copy /Y "${env.JAR_PATH}" "${env.RELEASE_JAR}"
+          certutil -hashfile "${env.RELEASE_JAR}" SHA256 > "${env.RELEASE_JAR}.sha256.txt"
         """
         archiveArtifacts artifacts: "target/${env.BUILD_NAME}, target/${env.BUILD_NAME}.sha256.txt", fingerprint: true
       }
     }
 
-    // --------- Despliegues no productivos en paralelo ---------
-    stage('Deploy non-prod (parallel)') {
+    // -------- Deploy paralelo: misma DB, distintos puertos --------
+    stage('Deploy DEV/QA/PROD (parallel)') {
       parallel {
         stage('Deploy DEV (smoke)') {
           steps {
             catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
               timeout(time: 40, unit: 'SECONDS') {
-                withEnv([
-                  "SPRING_PROFILES_ACTIVE=${APP_PROFILE}",
-                  "SPRING_DATASOURCE_URL=jdbc:mysql://${DB_HOST}:${DB_PORT}/${DEV_DB}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC",
-                  "SPRING_DATASOURCE_USERNAME=${DEV_USER}",
-                  "SPRING_DATASOURCE_PASSWORD=${DEV_PASS}",
-                  "SPRING_JPA_HIBERNATE_DDL_AUTO=update",
-                  "SERVER_PORT=${DEV_PORT}"
-                ]) {
+                withEnv(["ENV_PORT=${DEV_PORT}"]) {
                   bat """
-                    echo [DEV] Ejecutando: ${env.JAR_PATH} en puerto %SERVER_PORT% con DB ${DEV_DB}
-                    java -jar "${env.JAR_PATH}"
+                    echo [DEV] Ejecutando: ${env.RELEASE_JAR} en puerto %ENV_PORT% con DB %DB_NAME%
+                    java -jar "${env.RELEASE_JAR}" ^
+                      --spring.datasource.url="jdbc:mysql://%DB_HOST%:%DB_PORT%/%DB_NAME%?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC" ^
+                      --spring.datasource.username=%DB_USER% ^
+                      --spring.datasource.password=%DB_PASS% ^
+                      --spring.jpa.hibernate.ddl-auto=update ^
+                      --server.port=%ENV_PORT%
                   """
                 }
               }
@@ -103,49 +94,37 @@ pipeline {
           steps {
             catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
               timeout(time: 40, unit: 'SECONDS') {
-                withEnv([
-                  "SPRING_PROFILES_ACTIVE=${APP_PROFILE}",
-                  "SPRING_DATASOURCE_URL=jdbc:mysql://${DB_HOST}:${DB_PORT}/${QA_DB}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC",
-                  "SPRING_DATASOURCE_USERNAME=${QA_USER}",
-                  "SPRING_DATASOURCE_PASSWORD=${QA_PASS}",
-                  "SPRING_JPA_HIBERNATE_DDL_AUTO=update",
-                  "SERVER_PORT=${QA_PORT}"
-                ]) {
+                withEnv(["ENV_PORT=${QA_PORT}"]) {
                   bat """
-                    echo [QA] Ejecutando: ${env.JAR_PATH} en puerto %SERVER_PORT% con DB ${QA_DB}
-                    java -jar "${env.JAR_PATH}"
+                    echo [QA] Ejecutando: ${env.RELEASE_JAR} en puerto %ENV_PORT% con DB %DB_NAME%
+                    java -jar "${env.RELEASE_JAR}" ^
+                      --spring.datasource.url="jdbc:mysql://%DB_HOST%:%DB_PORT%/%DB_NAME%?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC" ^
+                      --spring.datasource.username=%DB_USER% ^
+                      --spring.datasource.password=%DB_PASS% ^
+                      --spring.jpa.hibernate.ddl-auto=update ^
+                      --server.port=%ENV_PORT%
                   """
                 }
               }
             }
           }
         }
-      }
-    }
 
-    // Gate manual antes de producción
-    stage('Aprobación para PRODUCCIÓN') {
-      steps {
-        input message: "¿Deploy a PRODUCCIÓN con artefacto ${env.BUILD_NAME}?", ok: "Continuar"
-      }
-    }
-
-    stage('Deploy PROD (smoke)') {
-      steps {
-        catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-          timeout(time: 40, unit: 'SECONDS') {
-            withEnv([
-              "SPRING_PROFILES_ACTIVE=${APP_PROFILE}",
-              "SPRING_DATASOURCE_URL=jdbc:mysql://${DB_HOST}:${DB_PORT}/${PROD_DB}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC",
-              "SPRING_DATASOURCE_USERNAME=${PROD_USER}",
-              "SPRING_DATASOURCE_PASSWORD=${PROD_PASS}",
-              "SPRING_JPA_HIBERNATE_DDL_AUTO=update",
-              "SERVER_PORT=${PROD_PORT}"
-            ]) {
-              bat """
-                echo [PROD] Ejecutando: ${env.JAR_PATH} en puerto %SERVER_PORT% con DB ${PROD_DB}
-                java -jar "${env.JAR_PATH}"
-              """
+        stage('Deploy PROD (smoke)') {
+          steps {
+            // PROD: si falla, que falle el pipeline
+            timeout(time: 40, unit: 'SECONDS') {
+              withEnv(["ENV_PORT=${PROD_PORT}"]) {
+                bat """
+                  echo [PROD] Ejecutando: ${env.RELEASE_JAR} en puerto %ENV_PORT% con DB %DB_NAME%
+                  java -jar "${env.RELEASE_JAR}" ^
+                    --spring.datasource.url="jdbc:mysql://%DB_HOST%:%DB_PORT%/%DB_NAME%?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC" ^
+                    --spring.datasource.username=%DB_USER% ^
+                    --spring.datasource.password=%DB_PASS% ^
+                    --spring.jpa.hibernate.ddl-auto=update ^
+                    --server.port=%ENV_PORT%
+                """
+              }
             }
           }
         }
@@ -155,7 +134,7 @@ pipeline {
 
   post {
     always {
-      echo "Artefactos publicados en 'Artifacts'. Los deploys son *smoke* con timeout (UNSTABLE esperado)."
+      echo "Artefactos listos en 'Artifacts'. DEV/QA/PROD desplegados en paralelo usando la MISMA DB."
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
     DB_HOST = 'localhost'
     DB_PORT = '3306'
     DB_NAME = 'blog'
-    DB_USER = 'user'
+    DB_USER = 'root'
     DB_PASS = 'root'
 
     // Puertos distintos por ambiente
@@ -111,4 +111,5 @@ pipeline {
     }
   }
 }
+
 

--- a/README.md
+++ b/README.md
@@ -122,12 +122,30 @@ type "blog-back-<BUILD>-<GITSHA>.jar.sha256.txt"
 
 Para ejecutar:
 
-java -jar ./blog-back-<BUILD>-<GITSHA>.jar \
-  --spring.datasource.url='jdbc:mysql://localhost:3306/blog?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC' \
-  --spring.datasource.username=root \
-  --spring.datasource.password=root \
-  --spring.jpa.hibernate.ddl-auto=update \
-  --server.port=8081
+cmd windows:
+
+set JAR=blog-back-5-b7e4f675aa95.jar
+set URL=jdbc:mysql://localhost:3306/blog?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+set USER=root
+set PASS=root
+
+rem 
+start "DEV"  cmd /c java -jar "%JAR%" --server.port=8081 --spring.datasource.url="%URL%" --spring.datasource.username=%USER% --spring.datasource.password=%PASS% --spring.jpa.hibernate.ddl-auto=update
+start "QA"   cmd /c java -jar "%JAR%" --server.port=8082 --spring.datasource.url="%URL%" --spring.datasource.username=%USER% --spring.datasource.password=%PASS% --spring.jpa.hibernate.ddl-auto=update
+start "PROD" cmd /c java -jar "%JAR%" --server.port=8083 --spring.datasource.url="%URL%" --spring.datasource.username=%USER% --spring.datasource.password=%PASS% --spring.jpa.hibernate.ddl-auto=update
+
+
+linux:
+
+JAR=blog-back-5-b7e4f675aa95.jar
+URL='jdbc:mysql://localhost:3306/blog?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC'
+USER=root
+PASS=root
+
+nohup java -jar "$JAR" --server.port=8081 --spring.datasource.url="$URL" --spring.datasource.username=$USER --spring.datasource.password=$PASS --spring.jpa.hibernate.ddl-auto=update > dev.log 2>&1 &
+nohup java -jar "$JAR" --server.port=8082 --spring.datasource.url="$URL" --spring.datasource.username=$USER --spring.datasource.password=$PASS --spring.jpa.hibernate.ddl-auto=update > qa.log 2>&1 &
+nohup java -jar "$JAR" --server.port=8083 --spring.datasource.url="$URL" --spring.datasource.username=$USER --spring.datasource.password=$PASS --spring.jpa.hibernate.ddl-auto=update > prod.log 2>&1 &
+
 
 ## 👥 Equipo
 


### PR DESCRIPTION
**Summary**

Show true parallelism: run the same JAR in DEV/QA/PROD simultaneously.

All three use the same MySQL database; only ports differ.

**Changes**

Jenkinsfile

New Deploy DEV/QA/PROD (parallel) stage with three parallel sub-stages.

Single DB via DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASS.

Per-env ports (defaults 8081/8082/8083).

Stamped artifact blog-back-${BUILD_NUMBER}-${GIT_SHA}.jar + SHA-256.

archiveArtifacts enabled.

Windows-safe quoting; no input redirection issues.

README

Short guide to run the same JAR in three “environments” against one DB.

Examples for CMD/PowerShell/Linux.

Note on using ddl-auto=none if schema must not change.

**How to verify**

Trigger the pipeline.

Confirm stage Deploy DEV/QA/PROD (parallel) shows three green branches.

Check logs: identical JDBC URL for all; ports 8081/8082/8083 (or configured values).

**Risks**

All instances share one DB (avoid concurrent schema changes).

**Rollback**

Revert the Jenkinsfile to the previous version.